### PR TITLE
update event schedule display

### DIFF
--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -13,7 +13,13 @@ import {
   TypographyH4,
 } from "@/components/ui/typography";
 import YouTubeVideoCard from "@/components/youtube-video-card";
-import { getDate, getMonthYear, localeDate, localeTime } from "@/lib/utils";
+import {
+  getDate,
+  getDay,
+  getMonthYear,
+  localeDate,
+  localeTime,
+} from "@/lib/utils";
 import { getEvent } from "@/services";
 import { MapPinIcon, UsersIcon, VideoIcon } from "lucide-react";
 import type { Metadata } from "next";
@@ -46,8 +52,11 @@ export async function generateMetadata({
 }
 
 function EventSchedule({ event }: { event: any }) {
+  const isSameDay =
+    localeDate(event.scheduledStart) === localeDate(event.scheduledEnd);
+
   return (
-    <div className="flex flex-row gap-3 items-center">
+    <div className="flex flex-row gap-3 items-center mt-2">
       <div>
         <p className="font-semibold text-xs text-white bg-black rounded-t-md p-2">
           {getMonthYear(event.scheduledStart)}
@@ -56,47 +65,36 @@ function EventSchedule({ event }: { event: any }) {
           {getDate(event.scheduledStart)}
         </TypographyH2>
       </div>
-
-      <div>
-        {localeDate(event.scheduledStart) !== localeDate(event.scheduledEnd) ? (
-          <>
+      {isSameDay ? (
+        <div className="flex flex-col">
+          <TypographyH2 className="text-md pb-0">
+            {getDay(event.scheduledStart)}, {localeDate(event.scheduledStart)}
+          </TypographyH2>
+          <p className="text-sm text-neutral-500">
+            {localeTime(event.scheduledStart)}
+            {event.scheduledEnd && ` - ${localeTime(event.scheduledEnd)}`}
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col">
+          <div className="flex flex-col sm:flex-row sm:items-center gap-0 sm:gap-2">
             <TypographyH2 className="text-md pb-0">
-              {localeDate(event.scheduledStart)}
+              {getDay(event.scheduledStart)}, {localeDate(event.scheduledStart)}
             </TypographyH2>
-            <p className="text-xs text-neutral-500">
+            <p className="text-sm text-neutral-500">
               {localeTime(event.scheduledStart)}
             </p>
-          </>
-        ) : (
-          <TypographyH2 className="text-md pb-0">
-            {localeTime(event.scheduledStart)}
-          </TypographyH2>
-        )}
-      </div>
-
-      {event.scheduledEnd && (
-        <>
-          <div>
-            <p className="text-xs text-neutral-500">s/d</p>
           </div>
-          <div>
-            {localeDate(event.scheduledStart) !==
-            localeDate(event.scheduledEnd) ? (
-              <>
-                <TypographyH2 className="text-md pb-0">
-                  {localeDate(event.scheduledEnd)}
-                </TypographyH2>
-                <p className="text-xs text-neutral-500">
-                  {localeTime(event.scheduledEnd)}
-                </p>
-              </>
-            ) : (
-              <TypographyH2 className="text-md pb-0">
-                {localeTime(event.scheduledEnd)}
-              </TypographyH2>
-            )}
+          <p className="text-xs text-neutral-500">s/d</p>
+          <div className="flex flex-col sm:flex-row sm:items-center gap-0 sm:gap-2">
+            <TypographyH2 className="text-md pb-0">
+              {getDay(event.scheduledEnd)}, {localeDate(event.scheduledEnd)}
+            </TypographyH2>
+            <p className="text-sm text-neutral-500">
+              {localeTime(event.scheduledEnd)}
+            </p>
           </div>
-        </>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
For same-day event:

| Mobile (Before) | Mobile (After) |
|-|-|
| <img width="300" alt="CleanShot 2024-12-20 at 21 17 19@2x" src="https://github.com/user-attachments/assets/ee65d86f-33e2-4319-98a5-260a97fab3f0" /> | <img width="300" alt="CleanShot 2024-12-20 at 21 17 33@2x" src="https://github.com/user-attachments/assets/41d796fa-4695-4541-a871-6612ae06eb80" /> |

| Desktop (Before) | Desktop (After) |
|-|-|
| <img width="300" alt="CleanShot 2024-12-20 at 21 18 41@2x" src="https://github.com/user-attachments/assets/602c9d18-1225-47d0-8f5d-9965e241b4d6" /> | <img width="300" alt="CleanShot 2024-12-20 at 21 18 57@2x" src="https://github.com/user-attachments/assets/9907faba-ac10-4dbc-9ab1-0ecd453415fa" /> |

For multiple-days event:

| Mobile (Before) | Mobile (After) |
|-|-|
| <img width="300" alt="CleanShot 2024-12-20 at 21 21 17@2x" src="https://github.com/user-attachments/assets/2f0de458-a377-47d0-91f4-f4ee08d84527" /> | <img width="300" alt="CleanShot 2024-12-20 at 21 21 00@2x" src="https://github.com/user-attachments/assets/a21c2f45-c873-416c-bd72-26d540bede6e" /> |

| Desktop (Before) | Desktop (After) |
|-|-|
| <img width="300" alt="CleanShot 2024-12-20 at 21 20 26@2x" src="https://github.com/user-attachments/assets/99115f74-69e4-4b02-aed8-0fccb78cd3f0" /> | <img width="300" alt="CleanShot 2024-12-20 at 21 20 44@2x" src="https://github.com/user-attachments/assets/98317625-4fc8-4b01-9096-9dd5c43930ac" /> |